### PR TITLE
Server: Fix an issue when a previous `ClientHandler.Id` reconnects then crashes the server.

### DIFF
--- a/AmeisenNavigation.Server/src/Main.cpp
+++ b/AmeisenNavigation.Server/src/Main.cpp
@@ -152,6 +152,8 @@ void OnClientConnect(ClientHandler* handler) noexcept
 
 void OnClientDisconnect(ClientHandler* handler) noexcept
 {
+    if (ClientPathBuffers.find(handler->GetId()) == ClientPathBuffers.end()) return;
+
     Nav->FreeClient(handler->GetId());
 
     if (ClientPathBuffers[handler->GetId()].first->points) delete[] ClientPathBuffers[handler->GetId()].first->points;
@@ -161,6 +163,8 @@ void OnClientDisconnect(ClientHandler* handler) noexcept
     if (ClientPathBuffers[handler->GetId()].second->points) delete[] ClientPathBuffers[handler->GetId()].second->points;
     if (ClientPathBuffers[handler->GetId()].second) delete ClientPathBuffers[handler->GetId()].second;
     ClientPathBuffers[handler->GetId()].second = nullptr;
+
+    ClientPathBuffers.erase(handler->GetId());
 
     LogI("Client Disconnected: ", handler->GetIpAddress(), ":", handler->GetPort());
 }


### PR DESCRIPTION
Good day!

Using Windows 10
Visual Studio 2022

**Repro steps:**
* Start `Server`
* Start `Tester`
* Exit `Tester`
* Start `Tester` again

Upon the reconnection, first the `OnClientDisconnect` is called, before `OnClientConnect`.

**Exception Image:**
![image](https://github.com/Jnnshschl/AmeisenNavigation/assets/367101/41ee4120-a796-4326-bafd-06095ce9026b)

**Result:**
* AmeisenNavigation.Server\src\Main.cpp > `OnClientDisconnect`

```
Exception thrown: read access violation.
std::unordered_map<unsigned __int64,std::pair<Path * __ptr64,Path * __ptr64>,std::hash<unsigned __int64>,std::equal_to<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,std::pair<Path * __ptr64,Path * __ptr64> > > >::operator[](...).**first** was nullptr.
```

**Note:**
Probably the provided fix is not the nicest, to uphold your standard, however it prevents crashing the server. Feel free to accept it or reject it. I just wanted to bring it to your attention.

I have to say i love your work, its amazing! It let me work on my own hobby project :)