### PR TITLE
Tester: Added `MapId` dropdown menu and `Stopwatch` no allocation

### DIFF
--- a/AmeisenNavigation.Tester/ContientSource.cs
+++ b/AmeisenNavigation.Tester/ContientSource.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace AmeisenNavigation.Tester
+{
+    public static class ContientSource
+    {
+        public static readonly Dictionary<int, string> Continents = new()
+        {
+            [0] = "Eastern Kingdoms",
+            [1] = "Kalimdor",
+            [530] = "Outland",
+            [571] = "Northrend",
+        };
+
+        public static Dictionary<int, string> GetChoises() => Continents;
+    }
+}

--- a/AmeisenNavigation.Tester/MainWindow.xaml
+++ b/AmeisenNavigation.Tester/MainWindow.xaml
@@ -6,8 +6,14 @@
         xmlns:local="clr-namespace:AmeisenNavigation.Tester"
         mc:Ignorable="d"
         Title="AmeisenNavigation Tester" Height="450" Width="900" MinHeight="450" MinWidth="900" Loaded="Window_Loaded">
+    <Window.Resources>
+        <ObjectDataProvider x:Key="ContentDict"
+                            ObjectType="{x:Type local:ContientSource}"
+                            MethodName="GetChoises"/>
+    </Window.Resources>
     <Grid>
-        <Button x:Name="ButtonRun" Content="GetPath" Margin="385,10,0,0" VerticalAlignment="Top" Click="ButtonRun_Click" Height="41" HorizontalAlignment="Left" Width="120" />
+        <ComboBox x:Name="ComboBoxMap" Margin="385,10,0,0"  ItemsSource="{Binding Source={StaticResource ContentDict}}" SelectedValue="Key" DisplayMemberPath="Value" HorizontalAlignment="Left" VerticalAlignment="Top" Width="120" Height="18"/>
+        <Button x:Name="ButtonRun" Content="GetPath" Margin="385,33,0,0" VerticalAlignment="Top" Click="ButtonRun_Click" Height="18" HorizontalAlignment="Left" Width="120" />
         <Rectangle x:Name="ImgRect" Margin="10,60,280,10" Fill="Gainsboro" />
         <Image x:Name="ImgCanvas" Margin="10,60,280,10" />
         <ListBox x:Name="PointList" Margin="0,300,10,10" HorizontalAlignment="Right" Width="265" />

--- a/AmeisenNavigation.Tester/MainWindow.xaml.cs
+++ b/AmeisenNavigation.Tester/MainWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using AnTCP.Client;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
@@ -8,7 +7,6 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Runtime.InteropServices.JavaScript;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media.Imaging;
@@ -35,6 +33,14 @@ namespace AmeisenNavigation.Tester
 
     public partial class MainWindow : Window
     {
+        private int MapId
+        {
+            get
+            {
+                return ComboBoxMap.SelectedItem is KeyValuePair<int, string> kvp ? kvp.Key : 0;
+            }
+        }
+
         public MainWindow()
         {
             InitializeComponent();
@@ -113,7 +119,7 @@ namespace AmeisenNavigation.Tester
                 }
             }
 
-            Vector3 pos = GetPoint(0);
+            Vector3 pos = GetPoint(MapId);
             TextBoxEndX.Text = pos.X.ToString();
             TextBoxEndY.Text = pos.Y.ToString();
             TextBoxEndZ.Text = pos.Z.ToString();
@@ -136,7 +142,7 @@ namespace AmeisenNavigation.Tester
                 }
             }
 
-            Vector3 pos = GetPoint(0);
+            Vector3 pos = GetPoint(MapId);
             TextBoxStartX.Text = pos.X.ToString();
             TextBoxStartY.Text = pos.Y.ToString();
             TextBoxStartZ.Text = pos.Z.ToString();
@@ -215,21 +221,21 @@ namespace AmeisenNavigation.Tester
                 Vector3 start = new(sX, sY, sZ);
                 Vector3 end = new(eX, eY, eZ);
 
-                Stopwatch sw = Stopwatch.StartNew();
+                long startTime = Stopwatch.GetTimestamp();
                 IEnumerable<Vector3> path = type switch
                 {
-                    PathType.STRAIGHT => GetPath(MessageType.PATH, 0, start, end, flags),
-                    PathType.RANDOM => GetPath(MessageType.RANDOM_PATH, 0, start, end, flags),
+                    PathType.STRAIGHT => GetPath(MessageType.PATH, MapId, start, end, flags),
+                    PathType.RANDOM => GetPath(MessageType.RANDOM_PATH, MapId, start, end, flags),
                     _ => throw new NotImplementedException(),
                 };
-                sw.Stop();
+                TimeSpan elapsedTime = Stopwatch.GetElapsedTime(startTime);
 
                 if (path == null || !path.Any())
                 {
                     return;
                 }
 
-                UpdateViews(path, sw.Elapsed);
+                UpdateViews(path, elapsedTime);
 
                 float minX = float.MaxValue;
                 float maxX = float.MinValue;


### PR DESCRIPTION
**Changes:**
* Tester: Added `MapId` dropdown menu to choose from.
* Tester: For measuring Request-Response time use latest `Stopwatch` recommendation avoid allocating Stopwatch object.

**Updated Tester application image**
![image](https://github.com/Jnnshschl/AmeisenNavigation/assets/367101/bf1f5a9a-21e5-42d2-8f4b-0345f0ac4a68)

**Possible improvements**
* Create an endpoint serverside which returns the available mapId's based on the loaded mmaps.
* In the Tester app create a mechanism to populate the dropdown.
* However making a human readable continent text could be challenging.

Gooday!